### PR TITLE
Integrated SWIG bindings generation as part of the build.

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -6,6 +6,7 @@ incdir = path.getabsolute("../include");
 bindir = path.getabsolute("../bin");
 examplesdir = path.getabsolute("../examples");
 testsdir = path.getabsolute("../tests");
+toolsdir = path.getabsolute("../tools");
 
 builddir = path.getabsolute("./" .. action);
 if _ARGS[1] then

--- a/src/SharpLLVM.Native/premake4.lua
+++ b/src/SharpLLVM.Native/premake4.lua
@@ -1,3 +1,28 @@
+function SetupSWIGBindings()
+  local c = configuration '**/LLVM.i'
+  
+    -- A message to display while this build step is running (optional)
+    buildmessage 'Generating bindings with SWIG for: %{file.name}'
+
+    -- One or more commands to run (required)
+    local prj = premake.api.scope.project.location
+    local gen = path.getrelative(prj, path.getabsolute(gendir))
+    local out = path.join(gen, '%{file.basename}_wrap.c')
+    local llvm = path.getrelative(prj, path.getabsolute(path.join(LLVMRootDir, "include")))
+    local swig = path.getrelative(prj, path.getabsolute(path.join(toolsdir, 'swig/swig')))
+
+    local cmd = '"' .. swig .. '" -w302 -csharp -I' .. llvm
+      .. " -namespace SharpLLVM -dllimport SharpLLVM.Native.dll"
+      .. " -outdir " .. gen .. " -o " .. out .. " %{file.relpath}"
+
+    buildcommands { cmd }
+
+    -- One or more outputs resulting from the build (required)
+    buildoutputs { path.join(gendir, '%{file.basename}_wrap.c') }
+
+  configuration(c)
+end
+
 project "SharpLLVM.Native"
 
   kind "SharedLib"
@@ -6,8 +31,15 @@ project "SharpLLVM.Native"
   SetupNativeProject()
 
   includedirs { "." }
-  files { "**.c" }
+  files
+  {
+  	path.join(gendir, "LLVM_wrap.c"),
+  	"../SharpLLVM/Bindings/**.i"
+  }
+
+  SetupSWIGBindings()
 
   SetupLLVMIncludes()
   SetupLLVMLibDirs()
   SetupLLVMLibs()
+

--- a/src/SharpLang.RuntimeInline/premake4.lua
+++ b/src/SharpLang.RuntimeInline/premake4.lua
@@ -1,3 +1,28 @@
+function SetupSWIGBindings()
+  local c = configuration 'Runtime.i'
+  
+    -- A message to display while this build step is running (optional)
+    buildmessage 'Generating bindings with SWIG for: %{file.name}'
+
+    -- One or more commands to run (required)
+    local prj = premake.api.scope.project.location
+    local gen = path.getrelative(prj, path.getabsolute(gendir))
+    local out = path.join(gen, '%{file.basename}_wrap.c')
+    local llvm = path.getrelative(prj, path.getabsolute(path.join(LLVMRootDir, "include")))
+    local swig = path.getrelative(prj, path.getabsolute(path.join(toolsdir, 'swig/swig')))
+
+    local cmd = '"' .. swig .. '" -w302 -csharp -I' .. llvm
+      .. " -namespace SharpLang.RuntimeInline -dllimport SharpLang.RuntimeInline.dll"
+      .. " -outdir " .. gen .. " -o " .. out .. " %{file.relpath}"
+
+    buildcommands { cmd }
+
+    -- One or more outputs resulting from the build (required)
+    buildoutputs { path.join(gendir, '%{file.basename}_wrap.c') }
+
+  configuration(c)
+end
+
 project "SharpLang.RuntimeInline"
 
   kind "SharedLib"
@@ -5,8 +30,10 @@ project "SharpLang.RuntimeInline"
 
   SetupNativeProject()
 
-  files { "*.h", "*_wrap.cpp", "*.i", "*.inc" }
+  files { "*.h", "Runtime_wrap.cpp", "*.i", "*.inc" }
   
+  SetupSWIGBindings()
+
   SetupLLVMIncludes()
   SetupLLVMLibDirs()
 


### PR DESCRIPTION
This will generate the bindings as part of the build with proper dependency tracking so it will only re-generate if the interface file changes. For this to work, the user needs to have swig in the tools directory, which is another dependency.

This will make it easier to use older LLVM revisions though, since with the pre-generated bindings it might happen that it references symbols that did not yet exist in the LLVM revision being used.
